### PR TITLE
RSR-11 Issue can not assign children as a parent

### DIFF
--- a/app/helpers/issues_helper.rb
+++ b/app/helpers/issues_helper.rb
@@ -1,6 +1,8 @@
 module IssuesHelper
   def parent_issue_options(current_issue)
-    current_project.issues.without_issue(current_issue).map do |issue|
+    issues = current_project.issues.without_issue(current_issue.self_and_descendants)
+
+    issues.map do |issue|
       [issue.subject, issue.id]
     end
   end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -38,6 +38,16 @@ class Issue < ApplicationRecord
   end
 
   def cannot_have_itself_as_parent
-    errors.add(:parent_id, "can't not be itself!") if self == parent
+    if parent_is_a_child_or_itself?
+      errors.add(:parent_id, "can't not be itself or a child of this Issue!")
+    end
+  end
+
+  def parent_is_a_child_or_itself?
+    if persisted?
+      self_and_descendants.include?(parent)
+    else
+      self == parent
+    end
   end
 end

--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -86,6 +86,14 @@ class IssueTest < ActiveSupport::TestCase
     assert_not issue.save, "Saved issue with itself as parent"
   end
 
+  test "can not have a child as an parent" do
+    project = FactoryBot.create :project
+    issue = FactoryBot.create :issue, project: project
+    child_issue = FactoryBot.create :issue, project: project, parent: issue
+
+    assert_not issue.update(parent: child_issue), "Saved issue with child as parent"
+  end
+
   test "can only have issues from that same project as parent" do
     invalid_parent =
       FactoryBot.create :issue, project: FactoryBot.create(:project)


### PR DESCRIPTION
If a issue assigns a child as a parent a infinite loop is created. The
issues is now validating that the parent is not included in the
children.

The validation is not thread save. If the parent is saved as a child
between validation and issue update the issue will have a child as a
parent.