### PR TITLE
RSR-19 Issues with sequenced id scoped by projects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "puma"
 gem "rails", "~> 6.0.2"
 gem "sass-rails"
 gem "scenic"
+gem "sequenced"
 gem "turbolinks"
 gem "webpacker"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,6 +370,9 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (2.3.0)
+    sequenced (3.2.0)
+      activerecord (>= 3.0)
+      activesupport (>= 3.0)
     shellany (0.0.1)
     signet (0.14.0)
       addressable (~> 2.3)
@@ -464,6 +467,7 @@ DEPENDENCIES
   sass-rails
   scenic
   selenium-webdriver
+  sequenced
   spring
   spring-watcher-listen
   stackdriver

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -16,7 +16,10 @@ class IssuesController < ApplicationController
 
   def update
     if issue.update(issue_params)
-      redirect_to project_issue_url(current_project_member.project_id, issue),
+      redirect_to project_issue_url(
+                    current_project_member.project_id,
+                    issue.sequential_id,
+                  ),
                   notice: "Issue was updated."
     else
       render partial: "form",
@@ -35,7 +38,10 @@ class IssuesController < ApplicationController
       )
 
     if issue.save
-      redirect_to project_issue_url(current_project_member.project_id, issue),
+      redirect_to project_issue_url(
+                    current_project_member.project_id,
+                    issue.sequential_id,
+                  ),
                   notice: "New issue created."
     else
       render partial: "form",
@@ -69,7 +75,9 @@ class IssuesController < ApplicationController
   def issue
     if params[:id]
       @issue ||=
-        Issue.with_project(current_project_member.project_id).find(params[:id])
+        Issue.with_project(current_project_member.project_id).find_by!(
+          sequential_id: params[:id],
+        )
     end
   end
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -14,6 +14,8 @@ class Issue < ApplicationRecord
   belongs_to :creator, class_name: "ProjectMember", optional: true
   belongs_to :assignee, class_name: "ProjectMember", optional: true
 
+  acts_as_sequenced scope: :project_id
+
   has_many :histories, dependent: :restrict_with_exception
 
   validates :creator_id, presence: true, if: :new_record?

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -78,7 +78,7 @@
           <% @issues.each do |issue| %>
             <tr>
               <th scope="row">
-                <%= link_to "#{issue.project.key}-#{issue.id}", project_issue_path(issue.project, issue) %>
+                <%= link_to "#{issue.project.key}-#{issue.sequential_id}", project_issue_path(issue.project, issue.sequential_id) %>
               </th>
               <td><%= issue.subject %></td>
               <td class="text-right"><%= issue.due_at ? l(issue.due_at, format: :short) : "" %></td>

--- a/app/views/issues/_children.html.erb
+++ b/app/views/issues/_children.html.erb
@@ -3,7 +3,7 @@
     <% issues_with_children.each do |issue, children| %>
       <li class="list-group-item">
         <div class="<%= children.present? ? "mb-2" : "" %>">
-          <%= link_to issue.subject, project_issue_path(current_project, issue) %>
+          <%= link_to issue.subject, project_issue_path(current_project, issue.sequential_id) %>
         </div>
         <%= render "children", issues_with_children: children %>
       </li>

--- a/app/views/issues/_form.html.erb
+++ b/app/views/issues/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: issue, url: if issue.persisted?
-                                   project_issue_path(current_project, issue)
+                                   project_issue_path(current_project, issue.sequential_id)
                                  else
                                    project_issues_path(issue.project)
                                  end, data: { controller: "form", action: "ajax:error->form#update" } do |f| %>

--- a/app/views/issues/index.html.erb
+++ b/app/views/issues/index.html.erb
@@ -11,10 +11,10 @@
     <% @issues.each do |issue| %>
       <tr>
         <th scope="row">
-          <%= link_to "#{issue.project.key}-#{issue.id}", project_issue_path(current_project, issue) %>
+          <%= link_to "#{issue.project.key}-#{issue.sequential_id}", project_issue_path(current_project, issue.sequential_id) %>
         </th>
         <td>
-          <%= link_to issue.subject, project_issue_path(current_project, issue) %>
+          <%= link_to issue.subject, project_issue_path(current_project, issue.sequential_id) %>
         </td>
         <td>
           <%= status_badge issue.status %>

--- a/app/views/issues/show.html.erb
+++ b/app/views/issues/show.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex justify-content-between align-items-center">
   <h2><%= @issue.subject %></h2>
-  <%= link_to "Edit", edit_project_issue_path(current_project, @issue), class: "btn btn-primary" %>
+  <%= link_to "Edit", edit_project_issue_path(current_project, @issue.sequential_id), class: "btn btn-primary" %>
 </div>
 
 <div class="card">
@@ -32,7 +32,7 @@
         </div>
         <div class="col">
           <hr>
-          Parent <%= link_to(@issue.parent.subject, project_issue_path(current_project, @issue.parent)) if @issue.parent %>
+          Parent <%= link_to(@issue.parent.subject, project_issue_path(current_project, @issue.parent.sequential_id)) if @issue.parent %>
           <hr>
         </div>
       </div>

--- a/db/migrate/20200425090417_add_sequental_id_to_issues_scoped_by_projects.rb
+++ b/db/migrate/20200425090417_add_sequental_id_to_issues_scoped_by_projects.rb
@@ -1,0 +1,26 @@
+class AddSequentalIdToIssuesScopedByProjects < ActiveRecord::Migration[6.0]
+  def up
+    add_column :issues, :sequential_id, :integer
+
+    execute <<~SQL
+      UPDATE issues
+      SET sequential_id = old_issues.next_sequential_id
+      FROM (
+        SELECT id, ROW_NUMBER()
+        OVER(
+          PARTITION BY project_id
+          ORDER BY id
+        ) AS next_sequential_id
+        FROM issues
+      ) old_issues
+      WHERE issues.id = old_issues.id
+    SQL
+
+    change_column :issues, :sequential_id, :integer, null: false
+    add_index :issues, %i[sequential_id project_id], unique: true
+  end
+
+  def down
+    remove_column :issues, :sequential_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_06_072638) do
+ActiveRecord::Schema.define(version: 2020_04_25_090417) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -90,9 +90,11 @@ ActiveRecord::Schema.define(version: 2020_04_06_072638) do
     t.bigint "creator_id"
     t.bigint "assignee_id"
     t.enum "status", default: "open", null: false, as: "issue_status"
+    t.integer "sequential_id", null: false
     t.index ["ancestry"], name: "index_issues_on_ancestry"
     t.index ["creator_id"], name: "index_issues_on_creator_id"
     t.index ["project_id"], name: "index_issues_on_project_id"
+    t.index ["sequential_id", "project_id"], name: "index_issues_on_sequential_id_and_project_id", unique: true
   end
 
   create_table "members", force: :cascade do |t|

--- a/test/integration/histories_for_issues_test.rb
+++ b/test/integration/histories_for_issues_test.rb
@@ -36,7 +36,7 @@ class HistoriesForIssuesTest < ActionDispatch::IntegrationTest
 
     SecureRandom.stub :uuid, request_id do
       assert_changes "PaperTrail::Version.where(request_id: request_id).count", from: 0, to: 1 do
-        patch project_issue_path(issue.project, issue),
+        patch project_issue_path(issue.project, issue.sequential_id),
               params: {
                 issue: { subject: "A new issue" },
               }

--- a/test/models/issue_test.rb
+++ b/test/models/issue_test.rb
@@ -58,6 +58,21 @@ class IssueTest < ActiveSupport::TestCase
     assert_includes Issue.assigned_to(member), issue_three
   end
 
+  test "#sequential_id, created scoped by project" do
+    project_a = FactoryBot.create :project
+    project_b = FactoryBot.create :project
+
+    project_a_issue_one = FactoryBot.create :issue, project: project_a
+    project_a_issue_two = FactoryBot.create :issue, project: project_a
+    project_b_issue_one = FactoryBot.create :issue, project: project_b
+    project_b_issue_two = FactoryBot.create :issue, project: project_b
+
+    assert_equal project_a_issue_one.sequential_id, 1
+    assert_equal project_a_issue_two.sequential_id, 2
+    assert_equal project_b_issue_one.sequential_id, 1
+    assert_equal project_b_issue_two.sequential_id, 2
+  end
+
   test "has parent and children" do
     project = FactoryBot.create :project
     parent = FactoryBot.create :issue, project: project

--- a/test/system/issues_test.rb
+++ b/test/system/issues_test.rb
@@ -104,7 +104,7 @@ class IssuesTest < ApplicationSystemTestCase
     issue =
       FactoryBot.create :issue, project: @project, creator: @project_member
 
-    visit project_issue_path(@project, issue)
+    visit project_issue_path(@project, issue.sequential_id)
 
     click_on "Edit"
 


### PR DESCRIPTION
A sequenced_id is added as a issue identifier scoped by projects. All
links to issues use the sequenced_id for navigation.