### PR TITLE
Alpine Linux environment supports issue history

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache \
     libpq \
     tzdata \
     imagemagick \
+    diffutils \
     && rm -rf /usr/share/man /tmp/* /var/cache/apk/*
 
 ENV PORT=8080 \


### PR DESCRIPTION
The issue history is shown through a diffes. The Alpine Linux
environment requires the GNU diffutils to support the diff view
utilities.